### PR TITLE
Fix default image tag of github-actions-exporter

### DIFF
--- a/charts/github-actions-exporter/values.yaml
+++ b/charts/github-actions-exporter/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/labbs/github-actions-exporter
   pullPolicy: IfNotPresent
-  tag: "v1.9.0"
+  tag: "1.9.0"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Issue

With default values, helm fails to deploy `github-actions-exporter` with `ErrImagePull`.

## Cause

`values.yaml` specifies `v1.9.0` as the default image tag,
while the actual tag is `1.9.0`.

<https://github.com/Labbs/github-actions-exporter/pkgs/container/github-actions-exporter/144968033?tag=1.9.0>
