### PR TITLE
Fix github-actions-exporter image tag

### DIFF
--- a/charts/github-actions-exporter/values.yaml
+++ b/charts/github-actions-exporter/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/labbs/github-actions-exporter
   pullPolicy: IfNotPresent
-  tag: "v1.9.0"
+  tag: "1.9.0"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
The image tag doesn't have the "v".